### PR TITLE
Removed all workaround & duplications for chameleons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <version.arquillian.algeron>1.0.0.Alpha6</version.arquillian.algeron>
     <version.kubernetes_client>2.0.7</version.kubernetes_client>
     <version.pact>3.5.0-beta.3</version.pact>
-    <version.chameleon.container.model>1.0.0.Final-SNAPSHOT</version.chameleon.container.model>
+    <version.chameleon.container.model>1.0.0.Beta2</version.chameleon.container.model>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <version.arquillian.algeron>1.0.0.Alpha6</version.arquillian.algeron>
     <version.kubernetes_client>2.0.7</version.kubernetes_client>
     <version.pact>3.5.0-beta.3</version.pact>
-    <version.chameleon.container.model>1.0.0.Beta1</version.chameleon.container.model>
+    <version.chameleon.container.model>1.0.0.Final-SNAPSHOT</version.chameleon.container.model>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/src/main/java/org/jboss/forge/arquillian/container/ChameleonContainerLoader.java
+++ b/src/main/java/org/jboss/forge/arquillian/container/ChameleonContainerLoader.java
@@ -1,0 +1,61 @@
+package org.jboss.forge.arquillian.container;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.arquillian.container.chameleon.Loader;
+import org.arquillian.container.chameleon.spi.model.Dist;
+import org.arquillian.container.chameleon.spi.model.Target;
+import org.jboss.forge.arquillian.container.model.Container;
+
+public class ChameleonContainerLoader {
+
+    private static final Pattern pattern = Pattern.compile("(?<=arquillian container).*(?=remote|managed|embedded)");
+
+    public void setGroupIdAndArtifactIdFromChameleon(List<Container> containerList) throws Exception {
+
+        final org.arquillian.container.chameleon.spi.model.Container[] chameleonContainers = loadContainers();
+
+        containerList.forEach(container -> {
+            Matcher m = pattern.matcher(container.getName().toLowerCase());
+            if (m.find()) {
+                Optional<String> containerName = Optional.ofNullable(m.group(0));
+                if (containerName.isPresent()) {
+                    String finalContainerName = containerName.get().trim();
+                    Arrays.stream(chameleonContainers)
+                        .filter(containerPredicate -> {
+                            final boolean matched = Arrays.stream(containerPredicate.getAdapters())
+                                .anyMatch(adapter -> adapter.getType()
+                                        .equalsIgnoreCase(container.getContainerType().toString()));
+
+                            return matched && containerPredicate.getName().equalsIgnoreCase(finalContainerName);
+                        })
+                        .forEach(chameleonContainer -> setGroupIdAndArtifactID(chameleonContainer, container));
+                }
+            }
+        });
+    }
+
+    private org.arquillian.container.chameleon.spi.model.Container[] loadContainers() throws Exception {
+        Loader loader = new Loader();
+
+        return loader.loadContainers(
+            Target.class.getClassLoader().getResourceAsStream("chameleon/default/containers.yaml"));
+    }
+
+    private void setGroupIdAndArtifactID(org.arquillian.container.chameleon.spi.model.Container chameleonContainer,
+        Container container) {
+        final Dist dist = chameleonContainer.getDist();
+        final String[] split = dist.coordinates().split(":");
+        if (split.length >= 2) {
+            container.setGroupId(split[0]);
+            container.setArtifactId(split[1]);
+        } else {
+            throw new IllegalStateException(
+                "Group Id or Artifact Id is missing in distribution of chameleon configuration for chameleonContainer: "
+                    + chameleonContainer.getName());
+        }
+    }
+}

--- a/src/main/java/org/jboss/forge/arquillian/container/model/Container.java
+++ b/src/main/java/org/jboss/forge/arquillian/container/model/Container.java
@@ -6,17 +6,11 @@
  */
 package org.jboss.forge.arquillian.container.model;
 
-import org.arquillian.container.chameleon.spi.model.Dist;
-import org.arquillian.container.chameleon.spi.model.Target;
-import org.jboss.forge.addon.dependencies.builder.DependencyBuilder;
-
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Optional;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.arquillian.container.chameleon.spi.model.Target;
+import org.jboss.forge.addon.dependencies.builder.DependencyBuilder;
 
 /**
  * @Author Paul Bakker - paul.bakker.nl@gmail.com
@@ -166,7 +160,6 @@ public class Container implements Comparable<Container> {
         final String name = getName().toLowerCase().replaceAll("arquillian (?:container )?", "");
 
         return name.replace(" ", "_").toUpperCase();
-
     }
 
     public boolean shouldIncludeDirectDependency() {
@@ -196,38 +189,6 @@ public class Container implements Comparable<Container> {
 
         return false;
     }
-
-    public void setGroupIdAndArtifactIdFromChameleonConfiguration(org.arquillian.container.chameleon.spi.model.Container... containers) throws Exception {
-        String pattern = "(?<=arquillian container).*(?=remote|managed|embedded)";
-
-        Pattern r = Pattern.compile(pattern);
-        Matcher m = r.matcher(this.getName().toLowerCase());
-
-        if (m.find()) {
-            Optional<String> containerName = Optional.ofNullable(m.group(0));
-            if (containerName.isPresent()) {
-                String finalContainerName = containerName.get().trim();
-                Arrays.stream(containers)
-                    .filter(container -> {
-                        final boolean matched = Arrays.stream(container.getAdapters())
-                            .anyMatch(adapter -> adapter.getType().equalsIgnoreCase(this.containerType.toString()));
-
-                        return matched && container.getName().equalsIgnoreCase(finalContainerName);
-                    })
-                    .forEach(container -> {
-                        final Dist dist = container.getDist();
-                        final String[] split = dist.coordinates().split(":");
-                        if (split.length >= 2) {
-                            this.setGroupId(split[0]);
-                            this.setArtifactId(split[1]);
-                        } else {
-                            throw new IllegalStateException("Group Id or Artifact Id is missing in distribution of chameleon configuration for container: " + container.getName());
-                        }
-                    });
-            }
-        }
-    }
-
 
     public boolean isVersionMatches(String version) throws Exception {
         final String chameleonTarget = getChameleonTarget(version);

--- a/src/main/resources/containers.json
+++ b/src/main/resources/containers.json
@@ -960,8 +960,6 @@
     ]
   },
   {
-    "artifact_id": "glassfish",
-    "group_id": "org.glassfish.main.distributions",
     "name": "Arquillian Container GlassFish Managed",
     "container_type": "MANAGED",
     "configurations": [
@@ -1052,8 +1050,6 @@
     ]
   },
   {
-    "artifact_id": "glassfish",
-    "group_id": "org.glassfish.main.distributions",
     "name": "Arquillian Container GlassFish Remote",
     "container_type": "REMOTE",
     "configurations": [
@@ -1114,8 +1110,6 @@
     ]
   },
   {
-    "artifact_id": "glassfish",
-    "group_id": "org.glassfish.main.distributions",
     "name": "Arquillian Container GlassFish Embedded",
     "container_type": "EMBEDDED",
     "configurations": [
@@ -1168,8 +1162,6 @@
     ]
   },
   {
-    "artifact_id": "payara",
-    "group_id": "fish.payara.distributions",
     "name": "Arquillian Container Payara Managed",
     "container_type": "MANAGED",
     "configurations": [
@@ -1260,8 +1252,6 @@
     ]
   },
   {
-    "artifact_id": "payara",
-    "group_id": "fish.payara.distributions",
     "name": "Arquillian Container Payara Remote",
     "container_type": "REMOTE",
     "configurations": [
@@ -1322,8 +1312,6 @@
     ]
   },
   {
-    "artifact_id": "payara",
-    "group_id": "fish.payara.distributions",
     "name": "Arquillian Container Payara Embedded",
     "container_type": "EMBEDDED",
     "configurations": [
@@ -1376,8 +1364,6 @@
     ]
   },
   {
-    "artifact_id": "tomcat",
-    "group_id": "org.apache.tomcat",
     "name": "Arquillian Container Tomcat Remote",
     "container_type": "REMOTE",
     "configurations": [
@@ -1414,8 +1400,6 @@
     ]
   },
   {
-    "artifact_id": "tomcat",
-    "group_id": "org.apache.tomcat",
     "name": "Arquillian Container Tomcat Managed",
     "container_type": "MANAGED",
     "configurations": [
@@ -1494,8 +1478,6 @@
     ]
   },
   {
-    "artifact_id": "jboss-as-dist",
-    "group_id": "org.jboss.as",
     "name": "Arquillian Container JBoss AS Managed 7.x",
     "container_type": "MANAGED",
     "configurations": [
@@ -1556,8 +1538,6 @@
     ]
   },
   {
-    "artifact_id": "jboss-as-dist",
-    "group_id": "org.jboss.as",
     "name": "Arquillian Container JBoss AS Embedded 7.x",
     "container_type": "EMBEDDED",
     "configurations": [
@@ -1618,8 +1598,6 @@
     ]
   },
   {
-    "artifact_id": "jboss-as-dist",
-    "group_id": "org.jboss.as",
     "name": "Arquillian Container JBoss AS Remote 7.x",
     "container_type": "REMOTE",
     "configurations": [
@@ -1638,8 +1616,6 @@
     ]
   },
   {
-    "artifact_id": "jboss-as-dist",
-    "group_id": "org.jboss.as",
     "name": "Arquillian Container JBoss AS Domain Managed 7.x",
     "container_type": "MANAGED",
     "configurations": [
@@ -1700,8 +1676,6 @@
     ]
   },
   {
-    "artifact_id": "jboss-as-dist",
-    "group_id": "org.jboss.as",
     "name": "Arquillian Container JBoss AS Domain Remote 7.x",
     "container_type": "REMOTE",
     "configurations": [
@@ -1720,8 +1694,6 @@
     ]
   },
   {
-    "artifact_id": "wildfly-dist",
-    "group_id": "org.wildfly",
     "name": "Arquillian Container WildFly Managed",
     "container_type": "MANAGED",
     "configurations": [
@@ -1782,8 +1754,6 @@
     ]
   },
   {
-    "artifact_id": "wildfly-dist",
-    "group_id": "org.wildfly",
     "name": "Arquillian Container WildFly Remote",
     "container_type": "REMOTE",
     "configurations": [
@@ -1802,8 +1772,6 @@
     ]
   },
   {
-    "artifact_id": "wildfly-dist",
-    "group_id": "org.wildfly",
     "name": "Arquillian Container WildFly Embedded",
     "container_type": "EMBEDDED",
     "configurations": [
@@ -1822,8 +1790,6 @@
     ]
   },
   {
-    "artifact_id": "wildfly-dist",
-    "group_id": "org.wildfly",
     "name": "Arquillian Container WildFly Domain Managed",
     "container_type": "MANAGED",
     "configurations": [
@@ -1884,8 +1850,6 @@
     ]
   },
   {
-    "artifact_id": "wildfly-dist",
-    "group_id": "org.wildfly",
     "name": "Arquillian Container WildFly Domain Remote",
     "container_type": "REMOTE",
     "configurations": [
@@ -1904,8 +1868,6 @@
     ]
   },
   {
-    "artifact_id": "jboss-as-dist",
-    "group_id": "org.jboss.as",
     "name": "Arquillian Container JBoss EAP Remote 7.x",
     "container_type": "REMOTE",
     "configurations": [
@@ -1924,8 +1886,6 @@
     ]
   },
   {
-    "artifact_id": "jboss-as-dist",
-    "group_id": "org.jboss.as",
     "name": "Arquillian Container JBoss EAP Managed 7.x",
     "container_type": "MANAGED",
     "configurations": [
@@ -1986,8 +1946,6 @@
     ]
   },
   {
-    "artifact_id": "jboss-as-dist",
-    "group_id": "org.jboss.as",
     "name": "Arquillian Container JBoss EAP Embedded 7.x",
     "container_type": "EMBEDDED",
     "configurations": [
@@ -2048,8 +2006,6 @@
     ]
   },
   {
-    "artifact_id": "jboss-as-dist",
-    "group_id": "org.jboss.as",
     "name": "Arquillian Container JBoss EAP Domain Remote 7.x",
     "container_type": "REMOTE",
     "configurations": [
@@ -2068,8 +2024,6 @@
     ]
   },
   {
-    "artifact_id": "jboss-as-dist",
-    "group_id": "org.jboss.as",
     "name": "Arquillian Container JBoss EAP Domain Managed 7.x",
     "container_type": "MANAGED",
     "configurations": [

--- a/src/test/java/org/jboss/forge/arquillian/container/ContainerTest.java
+++ b/src/test/java/org/jboss/forge/arquillian/container/ContainerTest.java
@@ -142,7 +142,7 @@ public class ContainerTest {
         final Container container = createContainerWithType(Identifier.JBOSS_AS.getArtifactID(),
             JBOSS_AS_7_REMOTE, ContainerType.MANAGED);
 
-        final String version = "7.2.0.Final";
+        final String version = "7.1.1.Final";
 
         assertThat(container.isSupportedByChameleon(version)).isTrue();
         assertThat(container.isVersionMatches(version)).isTrue();
@@ -153,7 +153,7 @@ public class ContainerTest {
         final Container container = createContainerWithType(Identifier.JBOSS_AS.getArtifactID(),
             JBOSS_AS_7_DOMAIN_REMOTE, ContainerType.MANAGED);
 
-        final String version = "7.2.0.Final";
+        final String version = "7.1.1.Final";
 
         assertThat(container.isSupportedByChameleon(version)).isTrue();
         assertThat(container.isVersionMatches(version)).isTrue();

--- a/src/test/java/org/jboss/forge/arquillian/container/provider/ContainerDirectoryParserTest.java
+++ b/src/test/java/org/jboss/forge/arquillian/container/provider/ContainerDirectoryParserTest.java
@@ -1,0 +1,83 @@
+package org.jboss.forge.arquillian.container.provider;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.jboss.forge.arquillian.container.model.Container;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+
+public class ContainerDirectoryParserTest {
+
+    private ContainerDirectoryParser containerDirectoryParser;
+
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    @Before
+    public void loadContainers() throws IOException {
+        containerDirectoryParser = new ContainerDirectoryParser();
+        containerDirectoryParser.containerDirectoryLocationProvider = new FileContainerIndexLocationProvider();
+    }
+
+    @Test
+    public void should_assigned_group_id_and_artifact_id_from_chameleon() throws IOException {
+        List<Container> containers = containerDirectoryParser.getContainers();
+
+        containers.forEach(container -> {
+            softly.assertThat(container.getGroupId()).isNotNull();
+            softly.assertThat(container.getArtifactId()).isNotNull();
+        });
+    }
+
+    @Test
+    public void should_assigned_group_id_and_artifact_id_for_tomcat() throws IOException {
+        final List<Container> containers = containerDirectoryParser.getContainers();
+        final Container container = getContainer("Arquillian Container Tomcat Remote", containers);
+
+        softly.assertThat(container.getGroupId()).isEqualTo("org.apache.tomcat");
+        softly.assertThat(container.getArtifactId()).isEqualTo("tomcat");
+    }
+
+    @Test
+    public void should_assigned_group_id_and_artifact_id_for_wildfly_managed() throws IOException {
+        final List<Container> containers = containerDirectoryParser.getContainers();
+        final Container container = getContainer("Arquillian Container WildFly Managed", containers);
+
+        softly.assertThat(container.getGroupId()).isEqualTo("org.wildfly");
+        softly.assertThat(container.getArtifactId()).isEqualTo("wildfly-dist");
+    }
+
+    @Test
+    public void should_assigned_group_id_and_artifact_id_for_jboss_as_managed_7() throws IOException {
+        final List<Container> containers = containerDirectoryParser.getContainers();
+        final Container container = getContainer("Arquillian Container JBoss AS Managed 7.x", containers);
+
+        softly.assertThat(container.getGroupId()).isEqualTo("org.jboss.as");
+        softly.assertThat(container.getArtifactId()).isEqualTo("jboss-as-dist");
+    }
+
+    @Test
+    public void should_assigned_group_id_and_artifact_id_for_payara_managed() throws IOException {
+        final List<Container> containers = containerDirectoryParser.getContainers();
+        final Container container = getContainer("Arquillian Container Payara Managed", containers);
+
+        softly.assertThat(container.getGroupId()).isEqualTo("fish.payara.distributions");
+        softly.assertThat(container.getArtifactId()).isEqualTo("payara");
+    }
+
+    private Container getContainer(String name, List<Container> containers) {
+        final Optional<Container> container = containers.stream().filter(containerPredicate -> containerPredicate.getName().equals(name))
+            .findFirst();
+
+        if (container.isPresent()) {
+            return container.get();
+        } else {
+            throw new IllegalStateException("No container found with name" + name);
+        }
+    }
+}

--- a/src/test/java/org/jboss/forge/arquillian/util/DependencyUtilTest.java
+++ b/src/test/java/org/jboss/forge/arquillian/util/DependencyUtilTest.java
@@ -57,29 +57,38 @@ public class DependencyUtilTest {
 
     @Test
     public void should_get_versions_only_supported_by_chameleon() throws Exception {
+        final Container container =
+            createContainer("container", Identifier.TOMCAT.getArtifactID(), Identifier.TOMCAT.getName());
+        final String groupId = container.getGroupId();
+        final String artifactId = container.getArtifactId();
+
+        // Assume following dependencies are getting after calling dependencyFacet.resolveAvailableVersions
         List<Coordinate> deps = new ArrayList<>();
-        deps.add(DependencyBuilder.create().setVersion("4.1").getCoordinate());
-        deps.add(DependencyBuilder.create().setVersion("2.1").getCoordinate());
-        deps.add(DependencyBuilder.create().setVersion("7.1").getCoordinate());
-        deps.add(DependencyBuilder.create().setVersion("1.0-SNAPSHOT").getCoordinate());
+        deps.add(DependencyBuilder.create().setGroupId(groupId).setArtifactId(artifactId).setVersion("4.1").getCoordinate());
+        deps.add(DependencyBuilder.create().setGroupId(groupId).setArtifactId(artifactId).setVersion("2.1").getCoordinate());
+        deps.add(DependencyBuilder.create().setGroupId(groupId).setArtifactId(artifactId).setVersion("7.1").getCoordinate());
+        deps.add(DependencyBuilder.create().setGroupId(groupId).setArtifactId(artifactId).setVersion("1.0-SNAPSHOT").getCoordinate());
 
-        List<String> dep = DependencyUtil.toVersionString(deps,
-            createContainer("tomcat", Identifier.TOMCAT.getArtifactID(), Identifier.TOMCAT.getName()));
+        List<String> dependenciesToEndUser = DependencyUtil.toVersionString(deps, container);
 
-        assertThat(dep).doesNotContain("2.1", "4.1");
-        assertThat(dep).contains("7.1");
+        assertThat(dependenciesToEndUser).doesNotContain("2.1", "4.1");
+        assertThat(dependenciesToEndUser).contains("7.1");
     }
 
     @Test
     public void should_get_all_available_versions_if_not_supported_by_chameleon() throws Exception {
-        List<Coordinate> deps = new ArrayList<>();
-        deps.add(DependencyBuilder.create().setVersion("4.1").getCoordinate());
-        deps.add(DependencyBuilder.create().setVersion("7.1").getCoordinate());
+        final Container container = createContainer("org.apache.openejb", "arquillian-openejb-embedded-4", "Arquillian Container OpenEJB Embedded 4");
+        final String groupId = container.getGroupId();
+        final String artifactId = container.getArtifactId();
 
-        List<String> dep = DependencyUtil.toVersionString(deps,
-            createContainer("org.jboss.as", "arquillian-jbossas-managed-4.2", "JBoss As"));
+        // Assume following dependencies are getting after calling dependencyFacet.resolveAvailableVersions
+        final List<Coordinate> deps = new ArrayList<>();
+        deps.add(DependencyBuilder.create().setGroupId(groupId).setArtifactId(artifactId).setVersion("4.7.4").getCoordinate());
+        deps.add(DependencyBuilder.create().setGroupId(groupId).setArtifactId(artifactId).setVersion("4.5.0").getCoordinate());
 
-        assertThat(dep).contains("4.1", "7.1");
+        List<String> dependenciesToEndUser = DependencyUtil.toVersionString(deps, container);
+
+        assertThat(dependenciesToEndUser).contains("4.7.4", "4.5.0");
     }
 
     @Test

--- a/src/test/java/org/jboss/forge/arquillian/util/DependencyUtilTest.java
+++ b/src/test/java/org/jboss/forge/arquillian/util/DependencyUtilTest.java
@@ -26,7 +26,7 @@ package org.jboss.forge.arquillian.util;
 import org.jboss.forge.addon.dependencies.Coordinate;
 import org.jboss.forge.addon.dependencies.builder.DependencyBuilder;
 import org.jboss.forge.arquillian.container.model.Container;
-import org.jboss.forge.arquillian.util.DependencyUtil;
+import org.jboss.forge.arquillian.container.model.ContainerType;
 import org.jboss.forge.arquillian.container.model.Identifier;
 import org.junit.Test;
 
@@ -64,7 +64,7 @@ public class DependencyUtilTest {
         deps.add(DependencyBuilder.create().setVersion("1.0-SNAPSHOT").getCoordinate());
 
         List<String> dep = DependencyUtil.toVersionString(deps,
-            createContainer(Identifier.TOMCAT.getArtifactID(), Identifier.TOMCAT.getName()));
+            createContainer("tomcat", Identifier.TOMCAT.getArtifactID(), Identifier.TOMCAT.getName()));
 
         assertThat(dep).doesNotContain("2.1", "4.1");
         assertThat(dep).contains("7.1");
@@ -77,7 +77,7 @@ public class DependencyUtilTest {
         deps.add(DependencyBuilder.create().setVersion("7.1").getCoordinate());
 
         List<String> dep = DependencyUtil.toVersionString(deps,
-            createContainer("arquillian-jbossas-managed-4.2", "JBoss As"));
+            createContainer("org.jboss.as", "arquillian-jbossas-managed-4.2", "JBoss As"));
 
         assertThat(dep).contains("4.1", "7.1");
     }
@@ -100,10 +100,12 @@ public class DependencyUtilTest {
         assertThat(dep).isNull();
     }
 
-    private Container createContainer(String artifactId, String name) {
+    private Container createContainer(String groupId, String artifactId, String name) {
         Container container = new Container();
+        container.setGroupId(groupId);
         container.setArtifactId(artifactId);
         container.setName(name);
+        container.setContainerType(ContainerType.MANAGED);
 
         return container;
     }


### PR DESCRIPTION
- Removed all workaround added to run chameleon.
- Now using groupId & ArtifactId from chameleon configuration.
- Depends on #https://github.com/arquillian/arquillian-container-chameleon/pull/70

