### PR TITLE
FORGEPLUGINS-217: Fixes compilation errors in Forge 3.7.2.Final+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <name>Arquillian Forge Addon</name>
   <properties>
     <version.arquillian_core>1.1.12.Final</version.arquillian_core>
-    <version.forge>3.5.1.Final</version.forge>
+    <version.forge>3.7.2.Final</version.forge>
     <version.jackson>1.9.1</version.jackson>
     <version.junit>4.12</version.junit>
     <version.shrinkwrap-maven-resolver>2.2.5</version.shrinkwrap-maven-resolver>
@@ -105,15 +105,8 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.forge.addon</groupId>
-      <artifactId>shell</artifactId>
-      <classifier>forge-addon</classifier>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.forge.addon</groupId>
       <artifactId>ui</artifactId>
       <classifier>forge-addon</classifier>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.forge.addon</groupId>
@@ -125,7 +118,6 @@
       <groupId>org.jboss.forge.addon</groupId>
       <artifactId>projects</artifactId>
       <classifier>forge-addon</classifier>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.forge.addon</groupId>


### PR DESCRIPTION
Motivation
----------
This is caused by FORGE-2759, but as specified in https://github.com/forge/core/#what-scope-should-my-addon-dependencies-be, exposed addons should not be in provided scope.

Modifications
-------------
Since UI classes are exposed to the outside world, it should not be declared as provided.

Result
------
Compilation succeeds and works on all Forge versions.